### PR TITLE
Add support for extracting page map from Adobe Digital Editions ePUBs

### DIFF
--- a/src/parser/epub.ts
+++ b/src/parser/epub.ts
@@ -1574,8 +1574,10 @@ const fillPageListFromPageMapXML = async (
             if (href === null || title === null) {
                 continue;
             }
+            const zipPath = path.join(path.dirname(pageMapZipPath), href)
+                .replace(/\\/g, "/");
 
-            link.Href = href;
+            link.Href = zipPath;
             link.Title = title;
             if (!publication.PageList) {
                 publication.PageList = [];


### PR DESCRIPTION
The purpose of this PR is to enable page map extraction from Adobe Digital Editions EPUBs.

ADE uses its own extension to EPUB to include a page map, as a stand-alone XML file.

This is important to Evident Point and our friends at NYU as their NYU press books use this scheme to map the publications with physical page numbers. There are other publishers out there that may have created content that have also used this.

More information can be found here:

- https://wiki.mobileread.com/wiki/Adobe_Digital_Editions#Page-map
- https://sites.google.com/site/constellationdigital/general-epub-challenges/ade-page-numbering