### PR TITLE
chore: Upgrade dependency xmldom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
   "packages": {
     "": {
       "name": "r2-shared-js",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@xmldom/xmldom": "^0.8.0",
         "debug": "^4.3.2",
         "fast-deep-equal": "^3.1.3",
         "image-size": "^1.0.0",
@@ -19,19 +20,17 @@
         "slugify": "^1.6.3",
         "ta-json-x": "^2.5.3",
         "tslib": "^2.3.1",
-        "xmldom": "^0.6.0",
         "xpath": "^0.0.32",
         "yazl": "^2.5.1"
       },
       "bin": {
-        "r2-shared-js-cli": "dist/es6-es2015/src/_utils/cli.js"
+        "r2-shared-js-cli": "dist/es8-es2017/src/_utils/cli.js"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/image-size": "^0.8.0",
         "@types/mime-types": "^2.1.1",
         "@types/node": "^16.11.10",
-        "@types/xmldom": "^0.1.31",
         "@types/yazl": "^2.4.2",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
@@ -1078,6 +1077,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+      "integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/acorn": {
@@ -10996,14 +11003,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/xpath": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
@@ -11948,6 +11947,11 @@
         "@typescript-eslint/types": "5.4.0",
         "eslint-visitor-keys": "^3.0.0"
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+      "integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg=="
     },
     "acorn": {
       "version": "8.6.0",
@@ -19682,11 +19686,6 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
       "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/readium/r2-shared-js",
   "dependencies": {
+    "@xmldom/xmldom": "^0.8.0",
     "debug": "^4.3.2",
     "fast-deep-equal": "^3.1.3",
     "image-size": "^1.0.0",
@@ -55,7 +56,6 @@
     "slugify": "^1.6.3",
     "ta-json-x": "^2.5.3",
     "tslib": "^2.3.1",
-    "xmldom": "^0.6.0",
     "xpath": "^0.0.32",
     "yazl": "^2.5.1"
   },
@@ -64,7 +64,6 @@
     "@types/image-size": "^0.8.0",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^16.11.10",
-    "@types/xmldom": "^0.1.31",
     "@types/yazl": "^2.4.2",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",

--- a/src/parser/cbz.ts
+++ b/src/parser/cbz.ts
@@ -8,7 +8,7 @@
 import * as mime from "mime-types";
 import * as path from "path";
 import * as slugify from "slugify";
-import * as xmldom from "xmldom";
+import * as xmldom from "@xmldom/xmldom";
 
 import { Metadata } from "@models/metadata";
 import { Contributor } from "@models/metadata-contributor";

--- a/src/parser/daisy-convert-ncc-to-opf-ncx.ts
+++ b/src/parser/daisy-convert-ncc-to-opf-ncx.ts
@@ -8,7 +8,7 @@
 import * as debug_ from "debug";
 import * as mime from "mime-types";
 import * as path from "path";
-import * as xmldom from "xmldom";
+import * as xmldom from "@xmldom/xmldom";
 
 import { timeStrToSeconds } from "@models/media-overlay";
 import { streamToBufferPromise } from "@r2-utils-js/_utils/stream/BufferUtils";

--- a/src/parser/daisy-convert-to-epub.ts
+++ b/src/parser/daisy-convert-to-epub.ts
@@ -9,7 +9,7 @@ import * as debug_ from "debug";
 import * as fs from "fs";
 import * as mime from "mime-types";
 import * as path from "path";
-import * as xmldom from "xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
 import { ZipFile } from "yazl";
 

--- a/src/parser/epub-daisy-common.ts
+++ b/src/parser/epub-daisy-common.ts
@@ -9,7 +9,7 @@ import * as debug_ from "debug";
 import * as mime from "mime-types";
 import * as moment from "moment";
 import * as path from "path";
-import * as xmldom from "xmldom";
+import * as xmldom from "@xmldom/xmldom";
 
 import { MediaOverlayNode, timeStrToSeconds } from "@models/media-overlay";
 import { DirectionEnum, MetadataSupportedKeys } from "@models/metadata";

--- a/src/parser/epub.ts
+++ b/src/parser/epub.ts
@@ -12,7 +12,7 @@ import { ISize } from "image-size/dist/types/interface";
 import * as moment from "moment";
 import * as path from "path";
 import { URL } from "url";
-import * as xmldom from "xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
 
 import { MediaOverlayNode, timeStrToSeconds } from "@models/media-overlay";


### PR DESCRIPTION
Switching from package `xmldom` to `@xmldom/xmldom`, which resolves the security issue present in latest xmldom version 0.6.0:
https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q

The reason is that the maintainers were forced to switch to a scoped package since 0.7.0:
 https://github.com/xmldom/xmldom/issues/271

- The reference to `@types/xmldom` can be dropped, since xmldom now comes with types as part of the package.
- I used node 16 to run `npm install`
- I did run `npm run build:all` on my machine after that, no error was reported.
- Some changes in the `package-lock.json` indicate that it was not in sync with the `package.json`, but I left them in place

I'm one of the xmldom maintainers. Don't hesitate to ask me questions.

I'mable to provide similar PRs for the following repos, but only after this one was landed (or we agreed which other repo should be taken care of first):
- https://github.com/readium/r2-opds-js
- https://github.com/readium/r2-streamer-js
- https://github.com/readium/r2-navigator-js

<details>
<summary>Changes in xmldom since 0.6.0</summary>
## [0.8.0](https://github.com/xmldom/xmldom/compare/0.7.5...0.8.0)

### Fixed
- Normalize all line endings according to XML specs [1.0](https://w3.org/TR/xml/#sec-line-ends) and [1.1](https://www.w3.org/TR/xml11/#sec-line-ends) \
  BREAKING CHANGE: Certain combination of line break characters are normalized to a single `\n` before parsing takes place and will no longer be preserved.
  - [`#303`](https://github.com/xmldom/xmldom/issues/303) / [`#307`](https://github.com/xmldom/xmldom/pull/307)
  - [`#49`](https://github.com/xmldom/xmldom/issues/49), [`#97`](https://github.com/xmldom/xmldom/issues/97), [`#324`](https://github.com/xmldom/xmldom/issues/324) / [`#314`](https://github.com/xmldom/xmldom/pull/314)
- XMLSerializer: Preserve whitespace character references [`#284`](https://github.com/xmldom/xmldom/issues/284) / [`#310`](https://github.com/xmldom/xmldom/pull/310) \
  BREAKING CHANGE: If you relied on the not spec compliant preservation of literal `\t`, `\n` or `\r` in **attribute values**.
  To preserve those you will have to create XML that instead contains the correct numerical (or hexadecimal) equivalent (e.g. `&#x9;`, `&#xA;`, `&#xD;`).
- Drop deprecated exports `DOMImplementation` and `XMLSerializer` from `lib/dom-parser.js` [#53](https://github.com/xmldom/xmldom/issues/53) / [`#309`](https://github.com/xmldom/xmldom/pull/309)
  BREAKING CHANGE: Use the one provided by the main package export.
- dom: Remove all links as part of `removeChild` [`#343`](https://github.com/xmldom/xmldom/issues/343) / [`#355`](https://github.com/xmldom/xmldom/pull/355)

### Chore
- ci: Restore latest tested node version to 16.x [`#325`](https://github.com/xmldom/xmldom/pull/325)
- ci: Split test and lint steps into jobs [`#111`](https://github.com/xmldom/xmldom/issues/111) / [`#304`](https://github.com/xmldom/xmldom/pull/304)
- Pinned and updated devDependencies

Thank you [@marrus-sh](https://github.com/marrus-sh), [@victorandree](https://github.com/victorandree), [@mdierolf](https://github.com/mdierolf), [@tsabbay](https://github.com/tsabbay), [@fatihpense](https://github.com/fatihpense) for your contributions

## 0.7.5

[Commits](https://github.com/xmldom/xmldom/compare/0.7.4...0.7.5)

### Fixes:

- Preserve default namespace when serializing [`#319`](https://github.com/xmldom/xmldom/issues/319) / [`#321`](https://github.com/xmldom/xmldom/pull/321)
  Thank you [@lupestro](https://github.com/lupestro)

## 0.7.4

[Commits](https://github.com/xmldom/xmldom/compare/0.7.3...0.7.4)

### Fixes:

- Restore ability to parse `__prototype__` attributes [`#315`](https://github.com/xmldom/xmldom/pull/315)
  Thank you [@dsimsonOMF](https://github.com/dsimsonOMF)

## 0.7.3

[Commits](https://github.com/xmldom/xmldom/compare/0.7.2...0.7.3)

### Fixes:

- Add doctype when parsing from string [`#277`](https://github.com/xmldom/xmldom/issues/277) / [`#301`](https://github.com/xmldom/xmldom/pull/301)
- Correct typo in error message [`#294`](https://github.com/xmldom/xmldom/pull/294)
  Thank you [@rrthomas](https://github.com/rrthomas)

### Refactor:

- Improve exports & require statements, new main package entry [`#233`](https://github.com/xmldom/xmldom/pull/233)

### Docs:

- Fix Stryker badge [`#298`](https://github.com/xmldom/xmldom/pull/298)
- Fix link to help-wanted issues [`#299`](https://github.com/xmldom/xmldom/pull/299)

### Chore:

- Execute stryker:dry-run on branches [`#302`](https://github.com/xmldom/xmldom/pull/302)
- Fix stryker config [`#300`](https://github.com/xmldom/xmldom/pull/300)
- Split test and lint scripts [`#297`](https://github.com/xmldom/xmldom/pull/297)
- Switch to stryker dashboard owned by org [`#292`](https://github.com/xmldom/xmldom/pull/292)

## 0.7.2

[Commits](https://github.com/xmldom/xmldom/compare/0.7.1...0.7.2)

### Fixes:

- Types: Add index.d.ts to packaged files [`#288`](https://github.com/xmldom/xmldom/pull/288)
  Thank you [@forty](https://github.com/forty)

## 0.7.1

[Commits](https://github.com/xmldom/xmldom/compare/0.7.0...0.7.1)

### Fixes:

- Types: Copy types from DefinitelyTyped [`#283`](https://github.com/xmldom/xmldom/pull/283)
  Thank you [@kachkaev](https://github.com/kachkaev)

### Chore:
- package.json: remove author, maintainers, etc. [`#279`](https://github.com/xmldom/xmldom/pull/279)

## 0.7.0 

[Commits](https://github.com/xmldom/xmldom/compare/0.6.0...0.7.0)

Due to [`#271`](https://github.com/xmldom/xmldom/issue/271) this version was published as
- unscoped `xmldom` package to github (git tags [`0.7.0`](https://github.com/xmldom/xmldom/tree/0.7.0) and [`0.7.0+unscoped`](https://github.com/xmldom/xmldom/tree/0.7.0%2Bunscoped))
- scoped `@xmldom/xmldom` package to npm (git tag `0.7.0+scoped`)
For more details look at [`#278`](https://github.com/xmldom/xmldom/pull/278#issuecomment-902172483)

### Fixes:

- Security: Misinterpretation of malicious XML input [`CVE-2021-32796`](https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q)
- Implement `Document.getElementsByClassName` as specified [`#213`](https://github.com/xmldom/xmldom/pull/213), thank you [@ChALkeR](https://github.com/ChALkeR)
- Inherit namespace prefix from parent when required [`#268`](https://github.com/xmldom/xmldom/pull/268)
- Handle whitespace in closing tags [`#267`](https://github.com/xmldom/xmldom/pull/267)
- Update `DOMImplementation` according to recent specs [`#210`](https://github.com/xmldom/xmldom/pull/210)  
  BREAKING CHANGE: Only if you "passed features to be marked as available as a constructor arguments" and expected it to "magically work".
- No longer serializes any namespaces with an empty URI [`#244`](https://github.com/xmldom/xmldom/pull/244)   
  (related to [`#168`](https://github.com/xmldom/xmldom/pull/168) released in 0.6.0)  
  BREAKING CHANGE: Only if you rely on ["unsetting" a namespace prefix](https://github.com/xmldom/xmldom/pull/168#issuecomment-886984994) by setting it to an empty string 
- Set `localName` as part of `Document.createElement` [`#229`](https://github.com/xmldom/xmldom/pull/229), thank you [@rrthomas](https://github.com/rrthomas)

### CI

- We are now additionally running tests against node v16
- Stryker tests on the master branch now run against node v14

### Docs

- Describe relations with and between specs: [`#211`](https://github.com/xmldom/xmldom/pull/211), [`#247`](https://github.com/xmldom/xmldom/pull/247)
</details>