### PR TITLE
Do not mark Traditional Chinese (zh-Hant and zh-TW) as a RTL language

### DIFF
--- a/src/parser/epub-daisy-common.ts
+++ b/src/parser/epub-daisy-common.ts
@@ -776,9 +776,7 @@ export const setPublicationDirection = (publication: Publication, opf: OPF) => {
 export const langStringIsRTL = (lang: string): boolean => {
     return lang === "ar" || lang.startsWith("ar-") ||
         lang === "he" || lang.startsWith("he-") ||
-        lang === "fa" || lang.startsWith("fa-") ||
-        lang === "zh-Hant" ||
-        lang === "zh-TW";
+        lang === "fa" || lang.startsWith("fa-");
 };
 
 export const getNcx = async (ncxManItem: Manifest, opf: OPF, zip: IZip): Promise<NCX> => {


### PR DESCRIPTION
This is a companion PR to https://github.com/edrlab/thorium-reader/pull/3027

I have only changed the RTL language logic for dependencies of [Thorium Reader](https://github.com/edrlab/thorium-reader) such that I get correct results in that program.
I may have missed other Readium repositories that may also feature such a language determination logic.

See https://github.com/edrlab/thorium-reader/pull/3027 for more details/rationale.